### PR TITLE
Allow matching against the end of string

### DIFF
--- a/lib/rexical/generator.rb
+++ b/lib/rexical/generator.rb
@@ -69,6 +69,8 @@ module Rexical
           @opt['--stub'] = true
         when /independent/i
           @opt['--independent'] = true
+        when /matcheos/i
+          @opt['--matcheos'] = true
         end
       end
     end
@@ -395,11 +397,11 @@ REX_EOT
       f.print REX_UTIL
 
       ## scanner method
-
+      eos_check = @opt["--matcheos"] ? "" : "return if @ss.eos?"
       f.print <<-REX_EOT
 
   def next_token
-    return if @ss.eos?
+    #{eos_check}
 
     # skips empty actions
     until token = _next_token or @ss.eos?; end
@@ -461,7 +463,16 @@ REX_EOT
 
         end
       end
+      if @opt["--matcheos"]
+        eos_check = <<-REX_EOT
+      when @@ss.scan(/$/)
+         ;
+        REX_EOT
+      else
+        eos_check = ""
+      end
       f.print <<-REX_EOT
+      #{eos_check}
       else
         text = @ss.string[@ss.pos .. -1]
         raise  ScanError, "can not match: '" + text + "'"

--- a/lib/rexical/rexcmd.rb
+++ b/lib/rexical/rexcmd.rb
@@ -22,6 +22,7 @@ o -s --stub             - append stub code for debug
 o -i --ignorecase       - ignore char case
 o -C --check-only       - syntax check only
 o -  --independent      - independent mode
+o -  --matcheos         - allow match against end of string
 o -d --debug            - print debug information
 o -h --help             - print this message and quit
 o -  --version          - print version and quit

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -235,6 +235,21 @@ end
     calc.state = nil
     assert_equal [:A, 'a'], calc.next_token
   end
+  def test_match_eos
+    lexer = build_lexer %q{
+class Calculator
+option
+matcheos
+rule
+      a        { [:A, text] }
+      $        { [:EOF, ""] }
+:B    b        { [:B, text] }
+     }
+     calc = lexer::Calculator.new
+     calc.scan_setup("a")
+     assert_equal [:A, 'a'], calc.next_token
+     assert_equal [:EOF, ""], calc.next_token
+  end
 
   def parse_lexer(str)
     rex = Rexical::Generator.new("--independent" => true)


### PR DESCRIPTION
In a parser we wrote using Rex we needed to generate and EOF token. Rexical does not allow matching against the end of the string by default. This commit allows matching against the end of string with the matcheos option. If the end of string is not matched, then by default next_token returns nil as if matcheos was not enabled.
