### PR TITLE
Uber rexical

### DIFF
--- a/DOCUMENTATION.en.rdoc
+++ b/DOCUMENTATION.en.rdoc
@@ -47,7 +47,7 @@
     ["macro"
       [macro-name  regular-expression] ]
     "rule"
-      [start-state]  pattern  [actions]
+      [start-state]  /pattern/[flags]  [actions]
     "end"
     [Footer Part]
 
@@ -59,9 +59,9 @@
       BLANK         \s+
       DIGIT         \d+
     rule
-      {BLANK}
-      {DIGIT}       { [:NUMBER, text.to_i] }
-      .             { [text, text] }
+      /{{BLANK}}/
+      /{{DIGIT}}/   { [:NUMBER, text.to_i] }
+      /./           { [text, text] }
     end
 
 
@@ -123,12 +123,14 @@
     REMIN         \/\*
     REMOUT        \*\/
 
+TODO: talk about whitespace
+TODO: talk about using macros in macros
 
 == Rule Section
 
   "rule" is start keyword.
 
-  [state]  pattern  [actions]
+  [state]  /pattern/[flags]  [actions]
 
 
 === state: Start State ( Optional )
@@ -142,11 +144,11 @@
 
 === pattern: String Pattern
 
-    The regular expression for specifying a character string.
-    The macro definition bundled with { } can be used for description 
-    of a regular expression.  A macro definition is used in order to use 
-    a regular expression including a blank.
-
+    The regular expression for specifying a character string. It is
+    surrounded by // and may be followed with regexp flags (currently
+    only /i). The macro definition bundled with {{ }} can be used for
+    description of a regular expression. A macro definition is used in
+    order to use a regular expression including a blank.
 
 === actions: Processing Actions ( Optional )
 
@@ -169,13 +171,13 @@
 
 === Rule Part Example
 
-        {REMIN}                 { state = :REM ; [:REM_IN, text] }
-  :REM  {REMOUT}                { state = nil ; [:REM_OUT, text] }
-  :REM  (.+)(?={REMOUT})        { [:COMMENT, text] }
-        {BLANK}
-        -?{DIGIT}               { [:NUMBER, text.to_i] }
-        {WORD}                  { [:word, text] }
-        .                       { [text, text] }
+        /{{REMIN}}/                 { state = :REM ; [:REM_IN, text] }
+  :REM  /{{REMOUT}}/                { state = nil ; [:REM_OUT, text] }
+  :REM  /(.+)(?={{REMOUT}})/        { [:COMMENT, text] }
+        /{{BLANK}}/
+        /-?{{DIGIT}}/               { [:NUMBER, text.to_i] }
+        /{{WORD}}/                  { [:word, text] }
+        /./                         { [text, text] }
 
 == Comment ( Optional )
 

--- a/DOCUMENTATION.ja.rdoc
+++ b/DOCUMENTATION.ja.rdoc
@@ -59,9 +59,9 @@
       BLANK         \s+
       DIGIT         \d+
     rule
-      {BLANK}
-      {DIGIT}       { [:NUMBER, text.to_i] }
-      .             { [text, text] }
+      /{{BLANK}}/
+      /{{DIGIT}}/   { [:NUMBER, text.to_i] }
+      /./           { [text, text] }
     end
 
 
@@ -118,12 +118,14 @@
     REMIN         \/\*
     REMOUT        \*\/
 
+TODO: talk about whitespace
+TODO: talk about using macros in macros
 
 == 走査規則
 
   この節は "rule" キーワードで始まる。
 
-  [state]  pattern  [actions]
+  [state]  /pattern/[flags]  [actions]
 
 
 === state: スタート状態（省略可能）
@@ -140,6 +142,12 @@
     正規表現の記述には、括弧で括ったマクロ定義を用いることができる。
     空白を含む正規表現を用いるには、マクロを使用する。
 
+TODO:
+    The regular expression for specifying a character string. It is
+    surrounded by // and may be followed with regexp flags (currently
+    only /i). The macro definition bundled with {{ }} can be used for
+    description of a regular expression. A macro definition is used in
+    order to use a regular expression including a blank.
 
 === actions: アクション（省略可能）
 
@@ -160,13 +168,13 @@
 
 === 走査規則定義例
 
-        {REMIN}                 { state = :REM ; [:REM_IN, text] }
-  :REM  {REMOUT}                { state = nil ; [:REM_OUT, text] }
-  :REM  (.+)(?={REMOUT})        { [:COMMENT, text] }
-        {BLANK}
-        -?{DIGIT}               { [:NUMBER, text.to_i] }
-        {WORD}                  { [:word, text] }
-        .                       { [text, text] }
+        /{{REMIN}}/                 { state = :REM ; [:REM_IN, text] }
+  :REM  /{{REMOUT}}/                { state = nil ; [:REM_OUT, text] }
+  :REM  /(.+)(?={{REMOUT}})/        { [:COMMENT, text] }
+        /{{BLANK}}/
+        /-?{{DIGIT}}/               { [:NUMBER, text.to_i] }
+        /{{WORD}}/                  { [:word, text] }
+        /./                         { [text, text] }
 
 
 == コメント（省略可能）

--- a/README.rdoc
+++ b/README.rdoc
@@ -17,11 +17,11 @@ Here is a sample lexical definition:
   macro
     BLANK         [\ \t]+
   rule
-    BLANK         # no action
-    \d+           { [:digit, text.to_i] }
-    \w+           { [:word, text] }
-    \n
-    .             { [text, text] }
+    /{{BLANK}}/     # no action
+    /\d+/           { [:digit, text.to_i] }
+    /\w+/           { [:word, text] }
+    /\n/
+    /./             { [text, text] }
   end
 
 Here is the command line usage:

--- a/lib/rexical/generator.rb
+++ b/lib/rexical/generator.rb
@@ -88,7 +88,7 @@ module Rexical
       end
       expr = st[0,ndx]
       expr.gsub!('\ ', ' ')
-      key  =  '{' + key + '}'
+      key  =  '{{' + key + '}}'
       @macro.each_pair do |k, e|
         expr.gsub!(k) { |m| e }
       end
@@ -221,7 +221,7 @@ module Rexical
       ss.scan(/\s+/)
       rule_state  =  ss.scan(/\:\S+/)
       ss.scan(/\s+/)
-      rule_expr  =  ss.scan(/\S+/)
+      rule_expr  =  ss.scan(/\/(\\\/|[^\/])+\/[i]?/)
       ss.scan(/\s+/)
       [rule_state, rule_expr, ss.post_match]
     end
@@ -412,13 +412,13 @@ module Rexical
             if rule_action
               if start_state
                 f.print <<-REX_EOT
-                  when((state == #{start_state}) and (text = @ss.scan(/#{rule_expr}/#{flag})))
+                  when((state == #{start_state}) and (text = @ss.scan(#{rule_expr}#{flag})))
                      action #{rule_action}
 
                 REX_EOT
               else
                 f.print <<-REX_EOT
-                  when (text = @ss.scan(/#{rule_expr}/#{flag}))
+                  when (text = @ss.scan(#{rule_expr}#{flag}))
                      action #{rule_action}
 
                 REX_EOT
@@ -426,13 +426,13 @@ module Rexical
             else
               if start_state
                 f.print <<-REX_EOT
-                  when (@state == #{start_state}) && (text = @ss.scan(/#{rule_expr}/#{flag}))
+                  when (@state == #{start_state}) && (text = @ss.scan(#{rule_expr}#{flag}))
                     ;
 
                 REX_EOT
               else
                 f.print <<-REX_EOT
-                  when (text = @ss.scan(/#{rule_expr}/#{flag}))
+                  when (text = @ss.scan(#{rule_expr}#{flag}))
                     ;
 
                 REX_EOT

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -39,8 +39,8 @@ class TestGenerator < Minitest::Test
 module Foo
 class Baz::Calculator < Bar
 rule
-  \d+       { [:NUMBER, text.to_i] }
-  \s+       { [:S, text] }
+  /\d+/       { [:NUMBER, text.to_i] }
+  /\s+/       { [:S, text] }
 end
 end
     }
@@ -52,8 +52,8 @@ end
     source = parse_lexer %q{
 class Calculator < Bar
 rule
-  \d+       { [:NUMBER, text.to_i] }
-  \s+       { [:S, text] }
+  /\d+/       { [:NUMBER, text.to_i] }
+  /\s+/       { [:S, text] }
 end
     }
 
@@ -64,8 +64,8 @@ end
     source = parse_lexer %q{
 class Calculator < Foo::Bar
 rule
-  \d+       { [:NUMBER, text.to_i] }
-  \s+       { [:S, text] }
+  /\d+/       { [:NUMBER, text.to_i] }
+  /\s+/       { [:S, text] }
 end
     }
 
@@ -76,8 +76,8 @@ end
     m = build_lexer %q{
 class Foo
 rule
-          \d      { @state = :digit; [:foo, text] }
-  :digit  \w      { @state = nil; [:w, text] }
+          /\d/      { @state = :digit; [:foo, text] }
+  :digit  /\w/      { @state = nil; [:w, text] }
 end
     }
     scanner = m::Foo.new
@@ -92,8 +92,8 @@ end
     m = build_lexer %q{
 class Calculator
 rule
-  \d+       { [:NUMBER, text.to_i] }
-  \s+       { [:S, text] }
+  /\d+/       { [:NUMBER, text.to_i] }
+  /\s+/       { [:S, text] }
 end
     }
 
@@ -111,8 +111,8 @@ end
     m = build_lexer %q{
 class Calculator
 rule
-  \d+       { [:NUMBER, text.to_i] }
-  \s+       # skips whitespaces
+  /\d+/       { [:NUMBER, text.to_i] }
+  /\s+/       # skips whitespaces
 end
     }
 
@@ -130,7 +130,7 @@ class Foo
 macro
   w  [\ \t]+
 rule
-  {w}  { [:SPACE, text] }
+  /{{w}}/  { [:SPACE, text] }
 end
     }
 
@@ -143,8 +143,8 @@ class Calculator
 macro
   digit     \d+
 rule
-  {digit}       { [:NUMBER, text.to_i] }
-  \s+       { [:S, text] }
+  /{{digit}}/       { [:NUMBER, text.to_i] }
+  /\s+/       { [:S, text] }
 end
     }
 
@@ -163,9 +163,9 @@ end
 class Calculator
 macro
   nonascii  [^\0-\177]
-  string    "{nonascii}*"
+  string    "{{nonascii}}*"
 rule
-  {string}       { [:STRING, text] }
+  /{{string}}/       { [:STRING, text] }
 end
     }
 
@@ -177,10 +177,10 @@ end
 class Calculator
 macro
   nonascii  [^\0-\177]
-  sing      {nonascii}*
-  string    "{sing}"
+  sing      {{nonascii}}*
+  string    "{{sing}}"
 rule
-  {string}       { [:STRING, text] }
+  /{{string}}/       { [:STRING, text] }
 end
     }
 
@@ -191,8 +191,8 @@ end
     lexer = build_lexer %q{
 class Calculator
 rule
-       a       { self.state = :B  ; [:A, text] }
-  :B   b       { self.state = nil ; [:B, text] }
+       /a/       { self.state = :B  ; [:A, text] }
+  :B   /b/       { self.state = nil ; [:B, text] }
 end
     }
 
@@ -218,8 +218,8 @@ end
     lexer = build_lexer %q{
 class Calculator
 rule
-       a       { [:A, text] }
-  :B   b       { [:B, text] }
+       /a/       { [:A, text] }
+  :B   /b/       { [:B, text] }
 end
     }
 
@@ -242,9 +242,9 @@ class Calculator
 option
 matcheos
 rule
-      a        { [:A, text] }
-      $        { [:EOF, ""] }
-:B    b        { [:B, text] }
+      /a/        { [:A, text] }
+      /$/        { [:EOF, ""] }
+:B    /b/        { [:B, text] }
      }
      calc = lexer::Calculator.new
      calc.scan_setup("a")


### PR DESCRIPTION
I dunno if this is the direction you want to go.

Most of these commits are whitespace and should probably go in. Much of the indentation in generator.rb are just plain wrong and made more unreadable by the heredocs. I've cleaned all that up.

The last commit in this series is the real meat tho, I made it so that actions look like ruby regexps, with `/`s and the ability to put flags on each regexp. I did NOT do this to macros since they can expand into themselves but probably should do something to address that (eg `Regexp.new(str, parsed_flags).source`). This change also means you can have regular whitespace in your regexps.

I also made it so that macros are expanded with `{{...}}` instead of `{...}` so that they're not ambiguous looking with ranges. I know that's not strictly necessary, but I use `{}`s a lot and needed better visual differentiation to not lose my mind.

Anyhow. Talk to me. I'm flexible on this and am happy doing a full fork if necessary.
