### PR TITLE
Update docs to reflect how state must now be used

### DIFF
--- a/DOCUMENTATION.en.rdoc
+++ b/DOCUMENTATION.en.rdoc
@@ -166,8 +166,8 @@
 
 === Example of Rule Section Definition
 
-        {REMIN}                 { state = :REM ; [:REM_IN, text] }
-  :REM  {REMOUT}                { state = nil ; [:REM_OUT, text] }
+        {REMIN}                 { self.state = :REM ; [:REM_IN, text] }
+  :REM  {REMOUT}                { self.state = nil ; [:REM_OUT, text] }
   :REM  (.+)(?={REMOUT})        { [:COMMENT, text] }
         {BLANK}
         -?{DIGIT}               { [:NUMBER, text.to_i] }

--- a/DOCUMENTATION.ja.rdoc
+++ b/DOCUMENTATION.ja.rdoc
@@ -160,8 +160,8 @@
 
 === Áöººµ¬Â§ÄêµÁÎã
 
-        {REMIN}                 { state = :REM ; [:REM_IN, text] }
-  :REM  {REMOUT}                { state = nil ; [:REM_OUT, text] }
+        {REMIN}                 { self.state = :REM ; [:REM_IN, text] }
+  :REM  {REMOUT}                { self.state = nil ; [:REM_OUT, text] }
   :REM  (.+)(?={REMOUT})        { [:COMMENT, text] }
         {BLANK}
         -?{DIGIT}               { [:NUMBER, text.to_i] }

--- a/sample/error2.rex
+++ b/sample/error2.rex
@@ -11,5 +11,5 @@ rule
   \d+           { [:digit, text.to_i] }
   \w+           { [:word, text] }
   \n
-  .             { state = :NONDEF ; [text, text] }
+  .             { self.state = :NONDEF ; [text, text] }
 end

--- a/sample/error2.rex.rb
+++ b/sample/error2.rex.rb
@@ -11,82 +11,81 @@ require 'racc/parser'
 #
 
 class Error2 < Racc::Parser
-      require 'strscan'
+  require 'strscan'
 
-      class ScanError < StandardError ; end
+  class ScanError < StandardError ; end
 
-      attr_reader   :lineno
-      attr_reader   :filename
-      attr_accessor :state
+  attr_reader   :lineno
+  attr_reader   :filename
+  attr_accessor :state
 
-      def scan_setup(str)
-        @ss = StringScanner.new(str)
-        @lineno =  1
-        @state  = nil
-      end
+  def scan_setup(str)
+    @ss = StringScanner.new(str)
+    @lineno =  1
+    @state  = nil
+  end
 
-      def action
-        yield
-      end
+  def action
+    yield
+  end
 
-      def scan_str(str)
-        scan_setup(str)
-        do_parse
-      end
-      alias :scan :scan_str
+  def scan_str(str)
+    scan_setup(str)
+    do_parse
+  end
+  alias :scan :scan_str
 
-      def load_file( filename )
-        @filename = filename
-        open(filename, "r") do |f|
-          scan_setup(f.read)
-        end
-      end
+  def load_file( filename )
+    @filename = filename
+    open(filename, "r") do |f|
+      scan_setup(f.read)
+    end
+  end
 
-      def scan_file( filename )
-        load_file(filename)
-        do_parse
-      end
+  def scan_file( filename )
+    load_file(filename)
+    do_parse
+  end
 
 
-        def next_token
-          return if @ss.eos?
+  def next_token
+    return if @ss.eos?
+    
+    # skips empty actions
+    until token = _next_token or @ss.eos?; end
+    token
+  end
 
-          # skips empty actions
-          until token = _next_token or @ss.eos?; end
-          token
-        end
+  def _next_token
+    text = @ss.peek(1)
+    @lineno  +=  1  if text == "\n"
+    token = case @state
+    when nil
+      case
+      when (text = @ss.scan(/[ \t]+/))
+        ;
 
-        def _next_token
-          text = @ss.peek(1)
-          @lineno  +=  1  if text == "\n"
-          token = case @state
-            when nil
-          case
-                  when (text = @ss.scan(/[ \t]+/))
-                    ;
+      when (text = @ss.scan(/\d+/))
+         action { [:digit, text.to_i] }
 
-                  when (text = @ss.scan(/\d+/))
-                     action { [:digit, text.to_i] }
+      when (text = @ss.scan(/\w+/))
+         action { [:word, text] }
 
-                  when (text = @ss.scan(/\w+/))
-                     action { [:word, text] }
+      when (text = @ss.scan(/\n/))
+        ;
 
-                  when (text = @ss.scan(/\n/))
-                    ;
+      when (text = @ss.scan(/./))
+         action { self.state = :NONDEF ; [text, text] }
 
-                  when (text = @ss.scan(/./))
-                     action { state = :NONDEF ; [text, text] }
+      else
+        text = @ss.string[@ss.pos .. -1]
+        raise  ScanError, "can not match: '" + text + "'"
+      end  # if
 
-          
-          else
-            text = @ss.string[@ss.pos .. -1]
-            raise  ScanError, "can not match: '" + text + "'"
-          end  # if
-
-        else
-          raise  ScanError, "undefined state: '" + state.to_s + "'"
-        end  # case state
-          token
-        end  # def _next_token
+    else
+      raise  ScanError, "undefined state: '" + state.to_s + "'"
+    end  # case state
+    token
+  end  # def _next_token
 
 end # class

--- a/sample/sample1.rex
+++ b/sample/sample1.rex
@@ -19,11 +19,11 @@ rule
 # [:state]  pattern  [actions]
 
 # remark
-                {REM_IN}        { state = :REMS; [:rem_in, text] }
-  :REMS         {REM_OUT}       { state = nil;   [:rem_out, text] }
+                {REM_IN}        { self.state = :REMS; [:rem_in, text] }
+  :REMS         {REM_OUT}       { self.state = nil;   [:rem_out, text] }
   :REMS         .*(?={REM_OUT}) {                [:remark, text] }
-                {REM}           { state = :REM;  [:rem_in, text] }
-  :REM          \n              { state = nil;   [:rem_out, text] }
+                {REM}           { self.state = :REM;  [:rem_in, text] }
+  :REM          \n              { self.state = nil;   [:rem_out, text] }
   :REM          .*(?=$)         {                [:remark, text] }
 
 # literal

--- a/sample/sample2.rex
+++ b/sample/sample2.rex
@@ -16,8 +16,8 @@ macro
   REMARK        \'              # '
 
 rule
-                {REMARK}        { state = :REM;  [:rem_in, text] } # '
-  :REM          \n              { state = nil;   [:rem_out, text] }
+                {REMARK}        { self.state = :REM;  [:rem_in, text] } # '
+  :REM          \n              { self.state = nil;   [:rem_out, text] }
   :REM          .*(?=$)         {                [:remark, text] }
 
                 \"[^"]*\"       { [:string, text] } # "

--- a/sample/xhtmlparser.rex
+++ b/sample/xhtmlparser.rex
@@ -28,34 +28,34 @@ macro
 rule
 
 # [:state]  pattern  [actions]
-                {XTAG_IN}               { state = :TAG; [:xtag_in, text] }
-                {ETAG_IN}               { state = :TAG; [:etag_in, text] }
-                {TAG_IN}                { state = :TAG; [:tag_in, text] }
-  :TAG          {EXT}                   { state = :EXT; [:ext, text] }
+                {XTAG_IN}               { self.state = :TAG; [:xtag_in, text] }
+                {ETAG_IN}               { self.state = :TAG; [:etag_in, text] }
+                {TAG_IN}                { self.state = :TAG; [:tag_in, text] }
+  :TAG          {EXT}                   { self.state = :EXT; [:ext, text] }
 
-  :EXT          {REM}                   { state = :REM; [:rem_in, text] }
-  :EXT          {XTAG_OUT}              { state = nil;  [:xtag_out, text] }
-  :EXT          {TAG_OUT}               { state = nil;  [:tag_out, text] }
+  :EXT          {REM}                   { self.state = :REM; [:rem_in, text] }
+  :EXT          {XTAG_OUT}              { self.state = nil;  [:xtag_out, text] }
+  :EXT          {TAG_OUT}               { self.state = nil;  [:tag_out, text] }
   :EXT          .+(?={REM})             {               [:exttext, text] }
   :EXT          .+(?={TAG_OUT})         {               [:exttext, text] }
   :EXT          .+(?=$)                 {               [:exttext, text] }
   :EXT          \n
 
-  :REM          {REM}                   { state = :EXT; [:rem_out, text] }
+  :REM          {REM}                   { self.state = :EXT; [:rem_out, text] }
   :REM          .+(?={REM})             {               [:remtext, text] }
   :REM          .+(?=$)                 {               [:remtext, text] }
   :REM          \n
 
   :TAG          {BLANK}
-  :TAG          {XTAG_OUT}              { state = nil;  [:xtag_out, text] }
-  :TAG          {ETAG_OUT}              { state = nil;  [:etag_out, text] }
-  :TAG          {TAG_OUT}               { state = nil;  [:tag_out, text] }
+  :TAG          {XTAG_OUT}              { self.state = nil;  [:xtag_out, text] }
+  :TAG          {ETAG_OUT}              { self.state = nil;  [:etag_out, text] }
+  :TAG          {TAG_OUT}               { self.state = nil;  [:tag_out, text] }
   :TAG          {EQUAL}                 {               [:equal, text] }
-  :TAG          {Q1}                    { state = :Q1;  [:quote1, text] } # '
-  :Q1           {Q1}                    { state = :TAG; [:quote1, text] } # '
+  :TAG          {Q1}                    { self.state = :Q1;  [:quote1, text] } # '
+  :Q1           {Q1}                    { self.state = :TAG; [:quote1, text] } # '
   :Q1           [^{Q1}]+(?={Q1})        {               [:value, text] }  # '
-  :TAG          {Q2}                    { state = :Q2;  [:quote2, text] } # "
-  :Q2           {Q2}                    { state = :TAG; [:quote2, text] } # "
+  :TAG          {Q2}                    { self.state = :Q2;  [:quote2, text] } # "
+  :Q2           {Q2}                    { self.state = :TAG; [:quote2, text] } # "
   :Q2           [^{Q2}]+(?={Q2})        {               [:value, text] }  # "
 
   :TAG          [\w\-]+(?={EQUAL})      {               [:attr, text] }


### PR DESCRIPTION
Back in the old rex days one could just set `state` in their grammer file. That won't work anymore. It's now interpreted as an assignment to a local.

I've update the docs and samples to reflect the new assignment paradigm.
